### PR TITLE
docs: clarify output shape and safe full-document packaging flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,16 @@ import { wrapInDocumentFragment } from '@ansonlai/docx-redline-js';
 const wrapped = wrapInDocumentFragment(rawOoxml, { includeNumbering: true, numberingXml });
 ```
 
+### Output shape guardrail (important for full-document packaging)
+
+When using full-document workflows, do not assume the returned payload can always be
+written directly to `word/document.xml`.
+
+- Some operation paths can return package payload (`<pkg:package ...>`).
+- Use `extractReplacementNodesFromOoxml(payload)` to normalize and detect source type.
+- Treat `sourceType === 'package'` as package-level output; do not write it into
+  `word/document.xml` as-is.
+
 ## Gotchas
 
 1. Call `configureXmlProvider` first in Node.js.
@@ -174,3 +184,4 @@ const wrapped = wrapInDocumentFragment(rawOoxml, { includeNumbering: true, numbe
 3. Paragraph APIs expect paragraph-level OOXML, not full `word/document.xml` in all cases.
 4. List operations may return `numberingXml` that must be merged into package parts.
 5. `useNativeApi: true` means standalone mode cannot fully handle that operation path.
+6. If output begins with `<pkg:package`, it is package-level OOXML, not a direct replacement for `word/document.xml`.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,25 @@ import { applyOperationToDocumentXml } from '@ansonlai/docx-redline-js/services/
 import { getParagraphText } from '@ansonlai/docx-redline-js/core/paragraph-targeting.js';
 ```
 
+### Output Shape Matrix
+
+Different APIs return different OOXML shapes. This table is a quick safety reference.
+
+| API | Typical input scope | Output field | Possible root/output shape | Safe to write directly into `word/document.xml` |
+|-----|----------------------|--------------|----------------------------|--------------------------------------------------|
+| `applyRedlineToOxml(...)` | Paragraph/range/table scope OOXML | `result.oxml` | Fragment, `<w:document>`, or package payload (`<pkg:package>`) | No. Inspect first. |
+| `applyRedlineToOxmlWithListFallback(...)` | Paragraph/range scope OOXML | `result.oxml` | Fragment, `<w:document>`, or package payload (`<pkg:package>`) | No. Inspect first. |
+| `reconcileMarkdownTableOoxml(...)` | Table or paragraph scope OOXML | `result.oxml` | Fragment or `<w:document>` (and sometimes package payload in structural flows) | No. Inspect first. |
+| `applyOperationToDocumentXml(...)` | Full `word/document.xml` string | `result.documentXml` | Usually `<w:document>`, but can include package payload (`<pkg:package>`) in some structural paths | Only when root is `<w:document>`. |
+| `extractReplacementNodesFromOoxml(...)` | Any OOXML output | `{ replacementNodes, numberingXml, sourceType }` | Normalized to `sourceType` enum (`fragment` / `document` / `package`) | Yes, this is the safe normalization helper. |
+
+### Do / Don't for Packaging
+
+- Do use `extractReplacementNodesFromOoxml(...)` when you are not sure what shape came back.
+- Do merge numbering/comments artifacts with `ensureNumberingArtifactsInZip(...)` and `ensureCommentsArtifactsInZip(...)`.
+- Don't write payloads that start with `<pkg:package` into `word/document.xml`.
+- Don't assume every API output is always paragraph-only OOXML.
+
 ## Working With `.docx` Files
 
 This package operates on OOXML strings (XML parts inside `.docx` zip archives), not raw `.docx` binaries.
@@ -156,7 +175,8 @@ Typical flow:
 import JSZip from 'jszip';
 import {
   configureXmlProvider,
-  applyRedlineToOxml,
+  applyOperationToDocumentXml,
+  extractReplacementNodesFromOoxml,
   ensureNumberingArtifactsInZip,
   validateDocxPackage
 } from '@ansonlai/docx-redline-js';
@@ -164,8 +184,26 @@ import {
 const zip = await JSZip.loadAsync(docxBuffer);
 const documentXml = await zip.file('word/document.xml').async('string');
 
-// Apply edits with applyRedlineToOxml(...)
-// Merge artifacts with ensureNumberingArtifactsInZip(...) as needed
+const opResult = await applyOperationToDocumentXml(
+  documentXml,
+  { type: 'redline', target: 'old text', modified: 'new text' },
+  'Editor'
+);
+
+const payload = opResult.documentXml;
+if (payload.includes('<pkg:package')) {
+  // Important: package payload is not valid content for word/document.xml.
+  // Normalize first instead of writing payload directly.
+}
+const extracted = extractReplacementNodesFromOoxml(payload);
+
+// Then merge replacement nodes + numbering/comments artifacts using your
+// package workflow, and only write valid document XML into word/document.xml.
+if (extracted.numberingXml) {
+  await ensureNumberingArtifactsInZip(zip, extracted.numberingXml);
+}
+
+await validateDocxPackage(zip);
 
 const output = await zip.generateAsync({ type: 'nodebuffer' });
 ```


### PR DESCRIPTION
## Summary
Thanks for maintaining this project. This PR is a docs-only clarification to reduce a packaging footgun I ran into while integrating full-document flows.

I may have misunderstood part of the output contract at first, so I framed this as guidance rather than an implementation claim.

### What this changes
- Adds an **Output Shape Matrix** in `README.md`
- Adds a short **Do / Don't for Packaging** section
- Adds a safer full-document snippet that calls out package payload detection
- Adds `AGENTS.md` guardrails for `<pkg:package>` outputs

### Why
Some API paths can return OOXML shapes that are not safe to write directly into `word/document.xml`.
An explicit note and helper pointer (`extractReplacementNodesFromOoxml`) should help prevent unreadable DOCX outputs from integration misuse.

### Scope
- Docs only
- No behavior/API changes

Related issue: #1
